### PR TITLE
Ods template loader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
             <artifactId>jOpenDocument</artifactId>
             <version>1.3</version>
         </dependency>
+        <dependency>
+            <groupId>dev.dirs</groupId>
+            <artifactId>directories</artifactId>
+            <version>26</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/KimaiOds.java
+++ b/src/main/java/com/example/KimaiOds.java
@@ -1,14 +1,16 @@
 package com.example;
 
-import java.io.File;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.format.TextStyle;
 import java.util.Locale;
 import java.util.Set;
 
+import org.jopendocument.dom.ODPackage;
 import org.jopendocument.dom.spreadsheet.Sheet;
-import org.jopendocument.dom.spreadsheet.SpreadSheet;
+
+import com.example.utils.OdsTemplateLoader;
 
 /**
  * Classe che si occupa di compilare un file ODS a partire da un template.
@@ -28,7 +30,6 @@ import org.jopendocument.dom.spreadsheet.SpreadSheet;
 public class KimaiOds {
 
 	private final Path outputFile;
-	private final String templateOds;
 	private final String nome;
 	private final boolean mesePrecedente;
 	private final Set<Integer> giorniConPresenza;
@@ -37,14 +38,12 @@ public class KimaiOds {
 	 * Costruttore.
 	 * 
 	 * @param outputFile          percorso del file ODS da salvare
-	 * @param templateOds         percorso del file template ODS da usare
 	 * @param nome                nome della persona da scrivere nella cella G6
 	 * @param mesePrecedente      true per usare il mese precedente, false per usare il mese corrente
 	 * @param giorniConPresenza   insieme dei giorni del mese in cui si è rilevata una presenza
 	 */
-	public KimaiOds(Path outputFile, String templateOds, String nome, boolean mesePrecedente, Set<Integer> giorniConPresenza) {
+	public KimaiOds(Path outputFile, String nome, boolean mesePrecedente, Set<Integer> giorniConPresenza) {
 		this.outputFile = outputFile;
-		this.templateOds = templateOds;
 		this.nome = nome;
 		this.mesePrecedente = mesePrecedente;
 		this.giorniConPresenza = giorniConPresenza;
@@ -58,8 +57,9 @@ public class KimaiOds {
 	public void esegui() {
 		try {
 			// Apri il file ODS dal template
-			File file = new File(templateOds);
-			Sheet sheet = SpreadSheet.createFromFile(file).getSheet(0);
+			OdsTemplateLoader templateLoader = new OdsTemplateLoader();
+			InputStream templateStream = templateLoader.resolveTemplateFile();
+			Sheet sheet = new ODPackage(templateStream).getSpreadSheet().getSheet(0);
 
 			// Scrivi il nome nella cella G6 (colonna 6, riga 5)
 			sheet.setValueAt(nome, 6, 5);

--- a/src/main/java/com/example/Main.java
+++ b/src/main/java/com/example/Main.java
@@ -78,7 +78,6 @@ public class Main {
         Path inputFile = Paths.get(args[0]);
         Path outputFile = Paths.get(System.getProperty("java.io.tmpdir"), "Kimai.output");
         String outputFormat = "ODS";
-        String presenzeTemplate = "E:\\Progetti\\Eclipse Workspace\\kimai-tool\\src\\main\\resources\\presenzeTemplate.ods";
 
         // Parsing degli argomenti
         switch (args.length) {
@@ -117,7 +116,7 @@ public class Main {
                     String risposta = scanner.nextLine().trim().toLowerCase();
                     boolean usaMesePrecedente = risposta.equals("s") || risposta.equals("si");
 
-                    new KimaiOds(outputFile, presenzeTemplate, nome, usaMesePrecedente, giorniConPresenza).esegui();
+                    new KimaiOds(outputFile, nome, usaMesePrecedente, giorniConPresenza).esegui();
                 }
                 break;
             }

--- a/src/main/java/com/example/utils/OdsTemplateLoader.java
+++ b/src/main/java/com/example/utils/OdsTemplateLoader.java
@@ -1,0 +1,85 @@
+package com.example.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.example.KimaiOds;
+import com.example.Main;
+
+import dev.dirs.ProjectDirectories;
+
+/**
+ * Classe per gestire il caricamento del template per l'output in formato ODS.
+ * 
+ * <p>
+ * Il template da fornire è un file ODS che viene poi riempito
+ * programmaticamente dalla classe {@link KimaiOds}.
+ * 
+ * <p>
+ * Il file di template <code>{@value #TEMPLATE_FILE_NAME}</code> viene cercato
+ * nelle seguenti posizioni, in ordine di priorità:
+ * <ol>
+ * <li>sotto la directory {@value com.example.Main#APPLICATION_NAME} in un
+ * percorso sotto la propria $HOME (OS dependent)
+ * <li>directory attuale
+ * <li>classpath
+ * </ol>
+ * 
+ * @see ProjectDirectories
+ */
+public class OdsTemplateLoader {
+
+	/**
+	 * Nome atteso per il file di template (FISSO)
+	 */
+	public static final String TEMPLATE_FILE_NAME = "presenzeTemplate.ods";
+
+	/**
+	 * Directory sotto la home dell'utente attuale nella quale verrà cercato il file
+	 * di template, se presente.
+	 * 
+	 * @see ProjectDirectories#configDir
+	 */
+	private final Path homeConfigDir;
+
+	/**
+	 * Directory corrente, ovvero directory di lavoro attuale del processo JVM che
+	 * richiama questa classe.
+	 */
+	private final Path currentDir;
+
+	/**
+	 * Crea una nuova istanza di {@link OdsTemplateLoader} inizializzando i path di
+	 * ricerca interni.
+	 */
+	public OdsTemplateLoader() {
+		ProjectDirectories baseDirs = ProjectDirectories.from("com.example", "IOOOTA", Main.APPLICATION_NAME);
+		this.homeConfigDir = Paths.get(baseDirs.configDir);
+		this.currentDir = Paths.get("").toAbsolutePath();
+	}
+
+	/**
+	 * Ottiene un puntamento al file di template da utilizzare in base alle
+	 * politiche di ricerca attuali.
+	 * 
+	 * @throws IOException in caso di errore di I/O in apertura dell'InputStream
+	 */
+	public InputStream resolveTemplateFile() throws IOException {
+		Path templateInHomeCfg = homeConfigDir.resolve(TEMPLATE_FILE_NAME);
+		Path templateInCwd = currentDir.resolve(TEMPLATE_FILE_NAME);
+
+		if (Files.isRegularFile(templateInHomeCfg) && Files.isReadable(templateInHomeCfg)) {
+			return Files.newInputStream(templateInHomeCfg);
+		}
+
+		if (Files.isRegularFile(templateInCwd) && Files.isReadable(templateInCwd)) {
+			return Files.newInputStream(templateInCwd);
+		}
+
+		return ClassLoader.getSystemResourceAsStream(TEMPLATE_FILE_NAME);
+	}
+
+}

--- a/src/main/java/com/example/utils/OdsTemplateLoader.java
+++ b/src/main/java/com/example/utils/OdsTemplateLoader.java
@@ -22,9 +22,9 @@ import dev.dirs.ProjectDirectories;
  * Il file di template <code>{@value #TEMPLATE_FILE_NAME}</code> viene cercato
  * nelle seguenti posizioni, in ordine di priorità:
  * <ol>
+ * <li>directory attuale
  * <li>sotto la directory {@value com.example.Main#APPLICATION_NAME} in un
  * percorso sotto la propria $HOME (OS dependent)
- * <li>directory attuale
  * <li>classpath
  * </ol>
  * 
@@ -71,12 +71,12 @@ public class OdsTemplateLoader {
 		Path templateInHomeCfg = homeConfigDir.resolve(TEMPLATE_FILE_NAME);
 		Path templateInCwd = currentDir.resolve(TEMPLATE_FILE_NAME);
 
-		if (Files.isRegularFile(templateInHomeCfg) && Files.isReadable(templateInHomeCfg)) {
-			return Files.newInputStream(templateInHomeCfg);
-		}
-
 		if (Files.isRegularFile(templateInCwd) && Files.isReadable(templateInCwd)) {
 			return Files.newInputStream(templateInCwd);
+		}
+		
+		if (Files.isRegularFile(templateInHomeCfg) && Files.isReadable(templateInHomeCfg)) {
+			return Files.newInputStream(templateInHomeCfg);
 		}
 
 		return ClassLoader.getSystemResourceAsStream(TEMPLATE_FILE_NAME);


### PR DESCRIPTION
Questa PR introduce una prima versione di un componente che incapsula una funzionalità di autocaricamento del file di template in base al suo eventuale posizionamento a sistema.

La priorità nel caricamento viene attualmente assegnata in questa maniera:

 1. file sotto la $HOME
 2. file nel path attuale ($PWD)
 3. file nel classpath